### PR TITLE
検索ワードを登録できるようにした

### DIFF
--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -18,7 +18,7 @@ class UrlsController < ApplicationController
   end
 
   def create
-    @url = Url.new(url_params)
+    @url = current_user.urls.new(url_params)
     if @url.save
       redirect_to @url, notice: "Url was successfully created."
     else
@@ -45,6 +45,6 @@ class UrlsController < ApplicationController
     end
 
     def url_params
-      params.require(:url).permit(:url, :user_id)
+      params.require(:url).permit(:url)
     end
 end

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -41,7 +41,7 @@ class UrlsController < ApplicationController
 
   private
     def set_url
-      @url = Url.find(params[:id])
+      @url = current_user.urls.find(params[:id])
     end
 
     def url_params

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -4,7 +4,7 @@ class UrlsController < ApplicationController
   before_action :set_url, only: [:show, :edit, :update, :destroy]
 
   def index
-    @urls = Url.all
+    @urls = current_user.urls
   end
 
   def show

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -12,6 +12,7 @@ class UrlsController < ApplicationController
 
   def new
     @url = Url.new
+    @url.keywords.build
   end
 
   def edit
@@ -45,6 +46,8 @@ class UrlsController < ApplicationController
     end
 
     def url_params
-      params.require(:url).permit(:url)
+      params.require(:url).permit(
+        :url,
+        keywords_attributes: [:keyword])
     end
 end

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -20,7 +20,7 @@ class UrlsController < ApplicationController
   def create
     @url = current_user.urls.new(url_params)
     if @url.save
-      redirect_to @url, notice: "Url was successfully created."
+      redirect_to @url, notice: "Urlを登録しました。"
     else
       render :new
     end
@@ -28,7 +28,7 @@ class UrlsController < ApplicationController
 
   def update
     if @url.update(url_params)
-      redirect_to @url, notice: "Url was successfully updated."
+      redirect_to @url, notice: "Urlを更新しました。"
     else
       render :edit
     end
@@ -36,7 +36,7 @@ class UrlsController < ApplicationController
 
   def destroy
     @url.destroy
-    redirect_to urls_url, notice: "Url was successfully destroyed."
+    redirect_to urls_url, notice: "Urlを削除しました。"
   end
 
   private

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -1,0 +1,2 @@
+class Keyword < ApplicationRecord
+end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Keyword < ApplicationRecord
   belongs_to :url
 end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -2,4 +2,5 @@
 
 class Keyword < ApplicationRecord
   belongs_to :url
+  validates :keyword, presence: true
 end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -1,2 +1,3 @@
 class Keyword < ApplicationRecord
+  belongs_to :url
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -2,5 +2,5 @@
 
 class Url < ApplicationRecord
   validates :url, presence: true
-  has_may :keywords
+  has_many :keywords
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -3,6 +3,6 @@
 class Url < ApplicationRecord
   validates :url, presence: true
   belongs_to :user
-  has_many :keywords
+  has_many :keywords, dependent: :destroy
   accepts_nested_attributes_for :keywords
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -3,4 +3,5 @@
 class Url < ApplicationRecord
   validates :url, presence: true
   has_many :keywords
+  belongs_to :user
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -2,4 +2,5 @@
 
 class Url < ApplicationRecord
   validates :url, presence: true
+  has_may :keywords
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -2,6 +2,7 @@
 
 class Url < ApplicationRecord
   validates :url, presence: true
-  has_many :keywords
   belongs_to :user
+  has_many :keywords
+  accepts_nested_attributes_for :keywords
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :urls, dependent: :destroy
 end

--- a/app/views/urls/_form.html.slim
+++ b/app/views/urls/_form.html.slim
@@ -11,8 +11,5 @@
   .field
     = form.label :url
     = form.text_field :url
-  .field
-    = form.label :user_id
-    = form.number_field :user_id
   .actions
     = form.submit

--- a/app/views/urls/_form.html.slim
+++ b/app/views/urls/_form.html.slim
@@ -11,5 +11,9 @@
   .field
     = form.label :url
     = form.text_field :url
+  .field
+    = form.fields_for :keywords do |keyword|
+      = keyword.label :keyword
+      = keyword.text_field :keyword
   .actions
     = form.submit

--- a/app/views/urls/index.html.slim
+++ b/app/views/urls/index.html.slim
@@ -5,16 +5,12 @@ table
     tr
       th
         | Url
-      th
-        | User
       th[colspan="3"]
   tbody
     - @urls.each do |url|
       tr
         td
           = url.url
-        td
-          = url.user_id
         td
           = link_to 'Show', url
         td

--- a/app/views/urls/show.html.slim
+++ b/app/views/urls/show.html.slim
@@ -1,7 +1,12 @@
 p
   strong
-    | Url:
+    | URL: 
   = @url.url
+p
+  strong
+    | 検索ワード: 
+  = @url.keywords.first.keyword
+
 = link_to 'Edit', edit_url_path(@url)
 |  | 
 = link_to 'Back', urls_path

--- a/app/views/urls/show.html.slim
+++ b/app/views/urls/show.html.slim
@@ -2,10 +2,6 @@ p
   strong
     | Url:
   = @url.url
-p
-  strong
-    | User:
-  = @url.user_id
 = link_to 'Edit', edit_url_path(@url)
 |  | 
 = link_to 'Back', urls_path

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,5 +63,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # not default
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -36,7 +36,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is

--- a/db/migrate/20200724084526_create_keywords.rb
+++ b/db/migrate/20200724084526_create_keywords.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateKeywords < ActiveRecord::Migration[6.0]
   def change
     create_table :keywords do |t|

--- a/db/migrate/20200724084526_create_keywords.rb
+++ b/db/migrate/20200724084526_create_keywords.rb
@@ -1,0 +1,10 @@
+class CreateKeywords < ActiveRecord::Migration[6.0]
+  def change
+    create_table :keywords do |t|
+      t.string :keyword
+      t.integer :url_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200724084526_create_keywords.rb
+++ b/db/migrate/20200724084526_create_keywords.rb
@@ -1,10 +1,11 @@
 class CreateKeywords < ActiveRecord::Migration[6.0]
   def change
     create_table :keywords do |t|
-      t.string :keyword
-      t.integer :url_id
+      t.string :keyword, null: false
+      t.integer :url_id, null: false
 
       t.timestamps
     end
+    add_index :keywords, :url_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_22_014504) do
+ActiveRecord::Schema.define(version: 2020_07_24_084526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "keywords", force: :cascade do |t|
+    t.string "keyword", null: false
+    t.integer "url_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["url_id"], name: "index_keywords_on_url_id"
+  end
 
   create_table "urls", force: :cascade do |t|
     t.string "url", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_07_24_084526) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,5 +43,4 @@ ActiveRecord::Schema.define(version: 2020_07_24_084526) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
 end

--- a/test/fixtures/keywords.yml
+++ b/test/fixtures/keywords.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  keyword: MyString
+  url_id: 1
+
+two:
+  keyword: MyString
+  url_id: 1

--- a/test/models/keyword_test.rb
+++ b/test/models/keyword_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class KeywordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/keyword_test.rb
+++ b/test/models/keyword_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 class KeywordTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,6 @@
-require 'test_helper'
+# frozen_string_literal: true
+
+require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
## 概要
URLを登録する時に検索ワードも登録できるようにしました。
ネストしたフォームを実装するのにgemのcocoonを使うか、Vue.jsで一から実装するか検討中のため、現状では1つの検索ワードしか登録できません。
最終的には複数の検索ワードを登録できるようにする予定です。

## スクリーンショット
### URL新規登録画面
![image](https://user-images.githubusercontent.com/53965479/88469237-25531780-cf2a-11ea-8d28-cd12e200c9dd.png)

### 詳細画面
![image](https://user-images.githubusercontent.com/53965479/88469247-5f241e00-cf2a-11ea-88b9-f70589454961.png)

## 関連Issue
#17  
#3 