### PR TITLE
cocoonを使ってURLと一緒に検索ワードを複数登録できるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 gem "devise"
 gem "devise-i18n"
 gem "slim-rails"
+gem "cocoon"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    cocoon (1.2.14)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     devise (4.7.2)
@@ -260,6 +261,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  cocoon
   devise
   devise-i18n
   html2slim

--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -8,12 +8,10 @@ class UrlsController < ApplicationController
   end
 
   def show
-    @keywords = @url.keywords
   end
 
   def new
     @url = Url.new
-    @url.keywords.build
   end
 
   def create
@@ -38,6 +36,6 @@ class UrlsController < ApplicationController
     def url_params
       params.require(:url).permit(
         :url,
-        keywords_attributes: [:keyword])
+        keywords_attributes: [:id, :keyword, :_destroy])
     end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,8 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
+// Not default
+require("jquery")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ require("channels")
 
 // Not default
 require("jquery")
+require("cocoon")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -4,5 +4,5 @@ class Url < ApplicationRecord
   validates :url, presence: true
   belongs_to :user
   has_many :keywords, dependent: :destroy
-  accepts_nested_attributes_for :keywords
+  accepts_nested_attributes_for :keywords, reject_if: :all_blank, allow_destroy: true
 end

--- a/app/views/urls/_form.html.slim
+++ b/app/views/urls/_form.html.slim
@@ -13,7 +13,8 @@
     = form.text_field :url
   .field
     = form.fields_for :keywords do |keyword|
-      = keyword.label :keyword
-      = keyword.text_field :keyword
+      = render 'keyword_fields', f: keyword
+    .links
+      = link_to_add_association '検索ワードを追加', form, :keywords
   .actions
     = form.submit

--- a/app/views/urls/_keyword_fields.html.slim
+++ b/app/views/urls/_keyword_fields.html.slim
@@ -1,0 +1,5 @@
+.nested-fields
+  .field
+    = f.label :keyword
+    = f.text_field :keyword
+  = link_to_remove_association "削除", f

--- a/app/views/urls/show.html.slim
+++ b/app/views/urls/show.html.slim
@@ -7,10 +7,9 @@ p
 p
   strong
     | 検索ワード
-  - if @keywords
-    - @keywords.each do |keyword|
-      ul
-        li = keyword.keyword
+    ul
+      - @url.keywords.each do |k|
+        li = k.keyword
 
 
 = link_to 'Destroy', @url, method: :delete, data: { confirm: 'Are you sure?' }

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require("webpack")
+environment.plugins.prepend("Provide",
+    new webpack.ProvidePlugin({
+        $: "jquery/src/jquery",
+        jQuery: "jquery/src/jquery"
+    })
+)
+
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
+    "jquery": "^3.5.1",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
+    "cocoon": "github:nathanvda/cocoon#c24ba53",
     "jquery": "^3.5.1",
     "turbolinks": "^5.2.0"
   },

--- a/test/system/urls_test.rb
+++ b/test/system/urls_test.rb
@@ -20,11 +20,12 @@ class UrlsTest < ApplicationSystemTestCase
     click_on "New Url"
 
     fill_in "Url", with: "https://example.com"
+    click_on "検索ワードを追加"
     fill_in "Keyword", with: "ruby スクール"
+    click_on "検索ワードを追加"
     click_on "Create Url"
 
     assert_text "Urlを登録しました。"
-    click_on "Back"
   end
 
   test "urlの詳細画面を表示する" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -3913,6 +3913,11 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-base64@^2.1.8:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.3.tgz#7afdb9b57aa7717e15d370b66e8f36a9cb835dc3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,6 +1844,10 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
+"cocoon@github:nathanvda/cocoon#c24ba53":
+  version "1.2.10"
+  resolved "https://codeload.github.com/nathanvda/cocoon/tar.gz/c24ba53b40e688e7d8b7212824139ec7f352a242"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"


### PR DESCRIPTION
## 概要
[cocoon](https://github.com/nathanvda/cocoon)を使ってURLと一緒に検索ワードを複数登録できるようにしました。

検索ワード数の制限はしていません。