### PR TITLE
URL一覧画面で、URLごとに登録済みの検索ワード数を表示するようにした

### DIFF
--- a/app/controllers/urls_controller.rb
+++ b/app/controllers/urls_controller.rb
@@ -8,6 +8,7 @@ class UrlsController < ApplicationController
   end
 
   def show
+    @keywords = @url.keywords.order(created_at: :desc)
   end
 
   def new

--- a/app/views/urls/index.html.slim
+++ b/app/views/urls/index.html.slim
@@ -4,13 +4,17 @@ table
   thead
     tr
       th
-        | Url
+        | URL
+      th
+        | 登録済み検索ワード数
       th[colspan="2"]
   tbody
     - @urls.each do |url|
       tr
         td
           = url.url
+        td
+          = url.keywords.count
         td
           = link_to 'Show', url
         td

--- a/app/views/urls/show.html.slim
+++ b/app/views/urls/show.html.slim
@@ -5,7 +5,7 @@ p
     | URL: 
   = @url.url
 
-- @url.keywords.each do |k|
+- @keywords.each do |k|
   p
     strong
       | 検索ワード 
@@ -16,7 +16,7 @@ p
         th 日付
         th 順位
     tbody
-      - k.rankings.each do |r|
+      - k.rankings.order(created_at: :desc).each do |r|
         tr
           td = l r.created_at, format: :short
           td = r.rank


### PR DESCRIPTION
## 概要
- URL一覧画面で、URLごとに登録済みの検索ワード数を表示するようにしました。
- 詳細画面で検索ワードと順位がcreated_atの降順に表示されるようにしました。