### PR TITLE
検索順位のデータをjsonで返すapiを実装

### DIFF
--- a/app/controllers/api/v1/ranks_controller.rb
+++ b/app/controllers/api/v1/ranks_controller.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 class Api::V1::RanksController < ApplicationController
+  before_action :set_urls, only: [:index]
+  skip_before_action :authenticate_user!
+
   def index
-    @urls = Url.all
   end
+
+  private
+    def set_urls
+      if User.find_by(api_key: params[:api_key])
+        user = User.find_by(api_key: params[:api_key])
+        @urls = user.urls
+      end
+    end
 end

--- a/app/controllers/api/v1/ranks_controller.rb
+++ b/app/controllers/api/v1/ranks_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Api::V1::RanksController < ApplicationController
+  def index
+    @urls = Url.all
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :confirmable
 
   has_many :urls, dependent: :destroy
+  has_secure_token :api_key
 end

--- a/app/views/api/v1/ranks/index.json.jbuilder
+++ b/app/views/api/v1/ranks/index.json.jbuilder
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+@urls.each do |url|
+  json.set! url.url do
+    url.keywords.each do |k|
+      json.set! k.keyword do
+        k.rankings.each do |r|
+          json.set! l(r.created_at, format: :short), r.rank
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,10 @@ Rails.application.routes.draw do
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
+
+  namespace "api" do
+    namespace "v1" do
+      resources :ranks, only: [:index]
+    end
+  end
 end

--- a/db/migrate/20200804030203_add_api_key_to_users.rb
+++ b/db/migrate/20200804030203_add_api_key_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddApiKeyToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :api_key, :string
+    add_index :users, :api_key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_02_064022) do
+ActiveRecord::Schema.define(version: 2020_08_04_030203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,8 @@ ActiveRecord::Schema.define(version: 2020_08_02_064022) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "api_key"
+    t.index ["api_key"], name: "index_users_on_api_key", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,9 +4,11 @@ user_1:
   email: user1@example.com
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   confirmed_at: <%= Time.now %>
+  api_key: user1apikey
 user_2:
   id: 2
   name: User_2
   email: user2@example.com
   encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>
   confirmed_at: <%= Time.now %>
+  api_key: user2apikey


### PR DESCRIPTION
## 概要
- usersテーブルにapi_keyカラムを追加して、アカウント登録した時にAPIキーが生成されるようにしました。
- `http://localhost:3000/api/v1/ranks.json?api_key=[APIキー]`でリクエストするとjsonのデータを取得できるようにしました。

## レスポンスサンプル
```json
{"URL": 
  {"検索ワード": 
    {"日付": "順位", "日付": "順位", "日付": "順位", "日付": "順位"},
   "検索ワード": {"日付": "順位", "日付": "順位", "日付": "順位", "日付": "順位"}
  },
"URL":
  {"検索ワード": {"日付": "順位", "日付": "順位", "日付": "順位", "日付": "順位"}},
"URL":
  {"検索ワード": {"日付": "順位", "日付": "順位", "日付": "順位", "日付": "順位"},
   "検索ワード": {"日付": "順位", "日付": "順位", "日付": "順位", "日付": "順位"}}
}
```