### PR TITLE
URL登録後に追加で検索ワードを登録できるようにした

### DIFF
--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -1,8 +1,21 @@
 # frozen_string_literal: true
 
 class KeywordsController < ApplicationController
-  before_action :set_url, only: [:destroy]
+  before_action :set_url, only: [:destroy, :new, :create]
   before_action :set_keyword, only: [:destroy]
+
+  def new
+    @keyword = Keyword.new
+  end
+
+  def create
+    @keyword = @url.keywords.new(keyword_params)
+    if @keyword.save
+      redirect_to url_path(params[:url_id]), notice: "検索ワード「#{@keyword.keyword}」を登録しました。"
+    else
+      render :new
+    end
+  end
 
   def destroy
     @keyword.destroy
@@ -16,5 +29,9 @@ class KeywordsController < ApplicationController
 
     def set_url
       @url = current_user.urls.find(params[:url_id])
+    end
+
+    def keyword_params
+      params.require(:keyword).permit(:keyword)
     end
 end

--- a/app/views/keywords/new.html.slim
+++ b/app/views/keywords/new.html.slim
@@ -1,0 +1,8 @@
+h1 検索ワード追加
+
+= form_with model: [@url, @keyword] do |form|
+  = form.label :keyword
+  = form.text_field :keyword
+  = form.submit
+
+= link_to '戻る', @url

--- a/app/views/urls/show.html.slim
+++ b/app/views/urls/show.html.slim
@@ -4,7 +4,7 @@ p
   strong
     | URL: 
   = @url.url
-
+= link_to '検索ワードを追加', new_url_keyword_path(@url)
 - @keywords.each do |k|
   p
     strong

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_for :users
   root "urls#index"
   resources :urls, except: [:edit, :update] do
-    resources :keywords, only: [:destroy]
+    resources :keywords, only: [:destroy, :new, :create]
   end
 
   if Rails.env.development?


### PR DESCRIPTION
## 概要
URL詳細ページで追加で検索ワードを登録できるようにしました。

今回の実装では、画面遷移ありで検索ワードを追加できるようにしているのですが、Vue.jsを使って画面遷移なしに追加できるようにしたいと思っています。
